### PR TITLE
Add HAgent YAML configuration for Verilog adder test

### DIFF
--- a/verilog_adder_test/hagent.yaml
+++ b/verilog_adder_test/hagent.yaml
@@ -1,0 +1,40 @@
+profiles:
+  - name: verilog_adder
+    title: "4-bit Adder Verilog Compilation and Testing"
+    description: "Compiles and tests a simple 4-bit ripple carry adder"
+    
+    configuration:
+      environment:
+        PATH: "$PATH:/usr/local/bin"
+      
+      # Source files to track
+      source: "track_repo_dir('src', ext='.v')"
+      
+      # Output files to track  
+      output: "track_build_dir('build', ext='.v')"
+    
+    apis:
+      - name: compile_verilog
+        description: "Compile Verilog source files"
+        command: "iverilog -o build/adder_compiled src/adder.v"
+        cwd: "$HAGENT_REPO_DIR"
+        
+      - name: compile_with_testbench
+        description: "Compile Verilog source and testbench"
+        command: "iverilog -o build/adder_test src/adder.v tests/adder_tb.v"
+        cwd: "$HAGENT_REPO_DIR"
+        
+      - name: run_testbench
+        description: "Run the adder testbench"
+        command: "vvp build/adder_test"
+        cwd: "$HAGENT_REPO_DIR"
+        
+      - name: check_syntax
+        description: "Check Verilog syntax without compilation"
+        command: "iverilog -t null src/adder.v"
+        cwd: "$HAGENT_REPO_DIR"
+        
+      - name: check_testbench_syntax
+        description: "Check testbench syntax"
+        command: "iverilog -t null src/adder.v tests/adder_tb.v"
+        cwd: "$HAGENT_REPO_DIR"


### PR DESCRIPTION
Defines compile, syntax check, and simulation steps for the 4-bit ripple carry adder example.